### PR TITLE
Use buffer.buffer property

### DIFF
--- a/buffer-to-arraybuffer.js
+++ b/buffer-to-arraybuffer.js
@@ -1,5 +1,5 @@
 (function(root) {
-  var isArrayBufferSupported = !!(new Buffer(0).buffer);
+  var isArrayBufferSupported = (new Buffer(0)).buffer instanceof ArrayBuffer;
 
   var bufferToArrayBuffer = isArrayBufferSupported ? bufferToArrayBufferSlice : bufferToArrayBufferCycle;
 

--- a/buffer-to-arraybuffer.js
+++ b/buffer-to-arraybuffer.js
@@ -1,6 +1,13 @@
 (function(root) {
+  var isArrayBufferSupported = !!(new Buffer(0).buffer);
 
-  function bufferToArrayBuffer(buffer) {
+  var bufferToArrayBuffer = isArrayBufferSupported ? bufferToArrayBufferSlice : bufferToArrayBufferCycle;
+
+  function bufferToArrayBufferSlice (buffer) {
+    return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+  }
+
+  function bufferToArrayBufferCycle (buffer) {
     var ab = new ArrayBuffer(buffer.length);
     var view = new Uint8Array(ab);
     for (var i = 0; i < buffer.length; ++i) {


### PR DESCRIPTION
From the [discussion](https://github.com/nodejs/node/issues/4420).

There is a way in node 4.x+ to slice Buffer’s ArrayBuffer instead of copying it per-element. [Benchmark ](https://tonicdev.com/dfcreative/hello) shows it is at least three times faster.

@miguelmota
