### PR TITLE
Update 'tape' dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   },
   "homepage": "https://github.com/miguelmota/buffer-to-arraybuffer",
   "devDependencies": {
-    "tape": "^3.0.3"
+    "tape": "^4.7.0"
   }
 }


### PR DESCRIPTION
Silences the following warning:

```
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```