### PR TITLE
Changed old usage of Buffer to new one.

### DIFF
--- a/buffer-to-arraybuffer.js
+++ b/buffer-to-arraybuffer.js
@@ -1,5 +1,5 @@
 (function(root) {
-  var isArrayBufferSupported = (new Buffer(0)).buffer instanceof ArrayBuffer;
+  var isArrayBufferSupported = (Buffer.alloc(0)).buffer instanceof ArrayBuffer;
 
   var bufferToArrayBuffer = isArrayBufferSupported ? bufferToArrayBufferSlice : bufferToArrayBufferCycle;
 

--- a/test/buffer-to-arraybuffer.js
+++ b/test/buffer-to-arraybuffer.js
@@ -17,7 +17,7 @@ test('bufferToArrayBuffer', function (t) {
 
   var str = 'abc';
 
-  var b = new Buffer(str.length);
+  var b = Buffer.alloc(str.length);
   b.write(str, 0);
 
   var ab = new ArrayBuffer(str.length);


### PR DESCRIPTION
`
[DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
`
